### PR TITLE
fix: name in join token should be optional

### DIFF
--- a/infra_provision/docs/HostactivationJoinToken.md
+++ b/infra_provision/docs/HostactivationJoinToken.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **ExpiresAt** | Pointer to **time.Time** |  | [optional] 
 **Id** | Pointer to **string** | The resource identifier. | [optional] [readonly] 
 **LastUsedAt** | Pointer to **time.Time** |  | [optional] [readonly] 
-**Name** | **string** |  | 
+**Name** | Pointer to **string** |  | [optional] 
 **Status** | Pointer to [**JoinTokenJoinTokenStatus**](JoinTokenJoinTokenStatus.md) |  | [optional] [default to JOINTOKENJOINTOKENSTATUS_UNKNOWN]
 **Tags** | Pointer to **map[string]interface{}** |  | [optional] 
 **TokenId** | Pointer to **string** | first half of the token. | [optional] [readonly] 
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 
 ### NewHostactivationJoinToken
 
-`func NewHostactivationJoinToken(name string, ) *HostactivationJoinToken`
+`func NewHostactivationJoinToken() *HostactivationJoinToken`
 
 NewHostactivationJoinToken instantiates a new HostactivationJoinToken object
 This constructor will assign default values to properties that have it defined,
@@ -178,6 +178,11 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *HostactivationJoinToken) HasName() bool`
+
+HasName returns a boolean if a field has been set.
 
 ### GetStatus
 

--- a/infra_provision/docs/UIJoinTokenAPI.md
+++ b/infra_provision/docs/UIJoinTokenAPI.md
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-    body := *openapiclient.NewHostactivationJoinToken("Name_example") // HostactivationJoinToken | 
+    body := *openapiclient.NewHostactivationJoinToken() // HostactivationJoinToken | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -377,7 +377,7 @@ import (
 
 func main() {
     id := "id_example" // string | An application specific resource identity of a resource
-    body := *openapiclient.NewHostactivationJoinToken("Name_example") // HostactivationJoinToken | 
+    body := *openapiclient.NewHostactivationJoinToken() // HostactivationJoinToken | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)

--- a/infra_provision/model_hostactivation_join_token.go
+++ b/infra_provision/model_hostactivation_join_token.go
@@ -26,7 +26,7 @@ type HostactivationJoinToken struct {
 	// The resource identifier.
 	Id         *string                   `json:"id,omitempty"`
 	LastUsedAt *time.Time                `json:"last_used_at,omitempty"`
-	Name       string                    `json:"name"`
+	Name       *string                   `json:"name,omitempty"`
 	Status     *JoinTokenJoinTokenStatus `json:"status,omitempty"`
 	Tags       map[string]interface{}    `json:"tags,omitempty"`
 	// first half of the token.
@@ -38,9 +38,8 @@ type HostactivationJoinToken struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewHostactivationJoinToken(name string) *HostactivationJoinToken {
+func NewHostactivationJoinToken() *HostactivationJoinToken {
 	this := HostactivationJoinToken{}
-	this.Name = name
 	var status JoinTokenJoinTokenStatus = JOINTOKENJOINTOKENSTATUS_UNKNOWN
 	this.Status = &status
 	return &this
@@ -216,28 +215,36 @@ func (o *HostactivationJoinToken) SetLastUsedAt(v time.Time) {
 	o.LastUsedAt = &v
 }
 
-// GetName returns the Name field value
+// GetName returns the Name field value if set, zero value otherwise.
 func (o *HostactivationJoinToken) GetName() string {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-
-	return o.Name
+	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *HostactivationJoinToken) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
-// SetName sets field value
+// HasName returns a boolean if a field has been set.
+func (o *HostactivationJoinToken) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
 func (o *HostactivationJoinToken) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetStatus returns the Status field value if set, zero value otherwise.
@@ -393,7 +400,9 @@ func (o HostactivationJoinToken) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastUsedAt) {
 		toSerialize["last_used_at"] = o.LastUsedAt
 	}
-	toSerialize["name"] = o.Name
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
+	}
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}


### PR DESCRIPTION
Name should be optional in model for join token. This is because we get an error for Patch operations if "name" is present in the body. 